### PR TITLE
ENH: Stop bsub waiting for CPU on same numa group as GPU

### DIFF
--- a/bin/submit_preproc.sh
+++ b/bin/submit_preproc.sh
@@ -71,7 +71,7 @@ if [[ ! -d "${outputBIDS}/code/logs" ]]; then
 fi
 
 bsub -cwd . -o "${outputBIDS}/code/logs/ftdc-t1w-preproc_${date}_%J.txt"\
-    -gpu "num=1:mode=exclusive_process:mps=no" \
+    -gpu "num=1:mode=exclusive_process:mps=no:gtile=1" \
     singularity run --containall --nv \
     -B /scratch:/tmp,${inputBIDS}:/input:ro,${outputBIDS}:/output,${inputList}:/input/list.txt \
     ${repoDir}/containers/ftdc-t1w-preproc-0.4.0.sif \


### PR DESCRIPTION
adding gtile=1 to stop jobs waiting for a CPU in the same numa group as the GPU.

This has potential performance implications, but I think should be OK for short jobs like hd-bet.